### PR TITLE
Develop_23.07.28

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,10 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Driver Matching System</title>
-    <script
-      type="text/javascript"
-      src="<%= htmlWebpackPlugin.options.kakaoAPIUrl %>"
-    ></script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,16 @@
 import React from "react";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import Main from "./pages/Main";
+import Signup from "./pages/Signup";
+import PassengerMap from "./pages/PassengerMap";
 
 function App() {
   return (
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<Main />} />
+        <Route path="/signup" element={<Signup />} />
+        <Route path="/map/passenger" element={<PassengerMap />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/atoms/Map.tsx
+++ b/src/components/atoms/Map.tsx
@@ -1,15 +1,19 @@
+/* eslint-disable */
 import { useEffect, useRef } from "react";
 import styled from "styled-components";
 import { BOTTOM_PADDING, TOP_PADDING } from "../../constants/layout";
+import { DEFAULT_LATITUDE, DEFAULT_LONGITUDE } from "../../constants/map";
+import { ICoordinate } from "../../types/map";
 
 declare global {
   interface Window {
-    // eslint-disable-next-line
     kakao: any;
   }
 }
 
-const { kakao } = window;
+interface Props {
+  setCoordinate: React.Dispatch<React.SetStateAction<ICoordinate>>;
+}
 
 const Wrapper = styled.div`
   width: 100%;
@@ -21,17 +25,58 @@ const Wrapper = styled.div`
   }
 `;
 
-function Map() {
-  const map = useRef<unknown>(null);
-
+function Map({ setCoordinate }: Props) {
   useEffect(() => {
-    const container = document.getElementById("map");
-    const options = {
-      center: new kakao.maps.LatLng(33.450701, 126.570667), // 지도의 중심좌표.
-      level: 3, // 지도의 레벨(확대, 축소 정도)
-    };
+    const mapScript = document.createElement("script");
+    mapScript.async = true;
+    mapScript.src = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.JAVASCRIPT_KEY}&autoload=false`;
+    document.head.appendChild(mapScript);
 
-    map.current = new window.kakao.maps.Map(container, options);
+    const onLoadKakaoMap = () => {
+      window.kakao.maps.load(() => {
+        const container = document.getElementById("map");
+        let latitude = DEFAULT_LATITUDE;
+        let longitude = DEFAULT_LONGITUDE;
+
+        const onSuccess = (position: any) => {
+          latitude = position.coords.latitude;
+          longitude = position.coords.longitude;
+          createMap(latitude, longitude);
+        };
+
+        const onError = () => {
+          createMap(latitude, longitude);
+        };
+
+        if (navigator.geolocation) {
+          navigator.geolocation.getCurrentPosition(onSuccess, onError);
+        } else {
+          onError();
+        }
+
+        const createMap = (latitude: number, longitude: number) => {
+          const options = {
+            center: new window.kakao.maps.LatLng(latitude, longitude),
+            level: 3, // 지도의 레벨(확대, 축소 정도)
+          };
+          const map = new window.kakao.maps.Map(container, options);
+          const marker = new window.kakao.maps.Marker({
+            position: map.getCenter(),
+          });
+          marker.setMap(map);
+          window.kakao.maps.event.addListener(
+            map,
+            "click",
+            (mouseEvent: any) => {
+              const latlng = mouseEvent.latLng;
+              marker.setPosition(latlng);
+              setCoordinate({ latitude: latlng.La, longitude: latlng.Ma });
+            }
+          );
+        };
+      });
+    };
+    mapScript.addEventListener("load", onLoadKakaoMap);
   }, []);
 
   return (

--- a/src/components/organism/PassengerService.tsx
+++ b/src/components/organism/PassengerService.tsx
@@ -1,0 +1,33 @@
+import styled from "styled-components";
+import { useState } from "react";
+import Map from "../atoms/Map";
+import BottomFixedButton from "../molecule/BottomFixedButton";
+import { ICoordinate } from "../../types/map";
+import { DEFAULT_LATITUDE, DEFAULT_LONGITUDE } from "../../constants/map";
+
+const Wrapper = styled.div``;
+
+function PassengerService() {
+  const [isCalled, setIsCalled] = useState(false);
+  const [coordinate, setCoordinate] = useState<ICoordinate>({
+    latitude: DEFAULT_LATITUDE,
+    longitude: DEFAULT_LONGITUDE,
+  });
+
+  const handleButtonClick = () => {
+    setIsCalled((prev) => !prev);
+  };
+
+  return (
+    <Wrapper>
+      <Map setCoordinate={setCoordinate} />
+      <BottomFixedButton
+        buttonText={isCalled ? "호출취소" : "호출하기"}
+        mode={isCalled ? "dark" : "light"}
+        onClick={handleButtonClick}
+      />
+    </Wrapper>
+  );
+}
+
+export default PassengerService;

--- a/src/constants/map.ts
+++ b/src/constants/map.ts
@@ -1,0 +1,3 @@
+// 기본 위도와 경도는 강남역을 기준으로 하였음
+export const DEFAULT_LATITUDE = 37.49799543887108;
+export const DEFAULT_LONGITUDE = 127.02755920374808;

--- a/src/pages/PassengerMap.tsx
+++ b/src/pages/PassengerMap.tsx
@@ -1,0 +1,15 @@
+// import Map from "../components/atoms/Map";
+import Header from "../components/molecule/Header";
+import PassengerService from "../components/organism/PassengerService";
+import Layout from "../styles/Layout";
+
+function PassengerMap() {
+  return (
+    <Layout>
+      <Header showRightArea />
+      <PassengerService />
+    </Layout>
+  );
+}
+
+export default PassengerMap;

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -1,0 +1,4 @@
+export interface ICoordinate {
+  latitude: number;
+  longitude: number;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,3 @@
-require("dotenv").config();
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer");
@@ -51,7 +50,6 @@ module.exports = {
     new CleanWebpackPlugin(),
     new HtmlWebpackPlugin({
       template: "./public/index.html",
-      kakaoAPIUrl: `//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.JAVASCRIPT_KEY}`,
       minify:
         process.env.NODE_ENV === "production"
           ? {


### PR DESCRIPTION
# 변경점
- 기존에는 index.html 파일에 kakao API 실행을 위한 script 태그를 삽입하였으나, API 특성상 script 태그에 secret key를 삽입해야 했었음.  dotenv를 이용하여 html 파일에 환경변수를 주입하기 위해서는 webpack.config.json을 거쳐야 했기 때문에 방식이 복잡하고, 코드가 장황해지는 문제점이 있었음.
따라서 Map 컴포넌트 내부에서 직접 index.html 파일 내 script 태그를 생성하는 방식을 변경하였음 (명령형 프로그래밍 스타일로 타협)
그 결과 환경변수 주입 문제를 해결할 수 있었음

- kakao map을 본격적으로 요구사항에 맞게 1차적으로 설정하였음. 일단 navigator 객체의 geolocation 값을 통해 브라우저의 현재 접속 위치를 기반으로 지도가 뜨도록 구현하였으며, geolocation이 지원되지 않는 경우 default 위치 값으로 강남역이 뜨도록 설정하였음. 

- 지도의 특정 위치를 클릭하면, pin이 그곳을 가리키도록 하였고, 콜백함수를 통해 해당 위치의 좌표값이 반환되도록 구현하였음.