### PR TITLE
fix: 브라우저의 다른 탭에서 서로 다른 계정 로그아웃시 발생하는 버그 수정

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -33,10 +33,20 @@ const useAuth = () => {
   };
 
   const signout = async () => {
-    await postSignout();
-    await signOut(auth);
-    tokenController.clear();
+    try {
+      await postSignout();
+    } catch (error) {
+      console.error(error);
+    }
+
+    try {
+      await signOut(auth);
+    } catch (error) {
+      console.error(error);
+    }
+
     setIsSignedin(false);
+    tokenController.clear();
   };
 
   return { isSignedin, signin, signout };

--- a/src/utils/tokenController.ts
+++ b/src/utils/tokenController.ts
@@ -9,22 +9,22 @@ export class TokenController {
   }
 
   getAccessToken() {
-    return localStorage.getItem(this.ACCESS_TOKEN_KEY);
+    return sessionStorage.getItem(this.ACCESS_TOKEN_KEY);
   }
 
   getTokenExpiryTime() {
-    return localStorage.getItem(this.TOKEN_EXPIRY_TIME_KEY);
+    return sessionStorage.getItem(this.TOKEN_EXPIRY_TIME_KEY);
   }
 
   setAccessToken(accessToken: string) {
-    localStorage.setItem(this.ACCESS_TOKEN_KEY, accessToken);
+    sessionStorage.setItem(this.ACCESS_TOKEN_KEY, accessToken);
   }
 
   setTokenExpiryTime() {
     const oneHourLater = new Date()
       .setHours(new Date().getHours() + 1)
       .toString();
-    localStorage.setItem(this.TOKEN_EXPIRY_TIME_KEY, oneHourLater);
+    sessionStorage.setItem(this.TOKEN_EXPIRY_TIME_KEY, oneHourLater);
   }
 
   isTokenExpired() {
@@ -33,7 +33,7 @@ export class TokenController {
   }
 
   clear() {
-    localStorage.removeItem(this.ACCESS_TOKEN_KEY);
-    localStorage.removeItem(this.TOKEN_EXPIRY_TIME_KEY);
+    sessionStorage.removeItem(this.ACCESS_TOKEN_KEY);
+    sessionStorage.removeItem(this.TOKEN_EXPIRY_TIME_KEY);
   }
 }


### PR DESCRIPTION
# 변경점
- 기존에는 token에 관한 정보를 localstorage에 저장했었으나, 이럴 경우 브라우저에서 탭을 여러 개 띄운 다음,  
탭마다 각각 다른 계정으로 로그인을 한 뒤, 나중에 특정 계정을 로그아웃 했을 때, localstorage에 저장된 token 정보가  
모든 탭에 걸쳐 사라지기 때문에, 또 다른 계정에서 로그아웃을 시도했을 때, 로그아웃 API 요청이 에러가 나는 문제가 발생하였음.  
이를 해결하기 위해 token 정보를 localstorage가 아닌 sessionstorage에 저장하도록 수정함.